### PR TITLE
일정 추가/ 편집 화면 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-native-gesture-handler": "^2.9.0",
     "react-native-modal": "^13.0.1",
     "react-native-safe-area-context": "4.5.0",
+    "react-native-select-dropdown": "^3.3.3",
     "react-native-shadow-2": "^7.0.7",
     "react-native-svg": "13.4.0",
     "react-native-vector-icons": "^9.2.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.17.11",
+    "@react-native-community/datetimepicker": "6.7.3",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/stack": "^6.3.16",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import CreateNotiScreen from './screens/CreateNotiScreen';
 import ModifyNotiScreen from './screens/ModifyNotiScreen';
 import MeetSearchSreen from './screens/MeetSearchScreen';
 import { RootStackParamList } from './types';
+import AddSchduleScreen from './screens/AddScheduleScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -21,12 +22,17 @@ const App = () => {
   return (
     <NavigationContainer>
       <Stack.Navigator>
-        <Stack.Screen
+        {/* <Stack.Screen
           name='Splash'
           component={SplashScreen}
           options={{ headerShown: false }}
-        />
+        /> */}
         <Stack.Screen
+          name='AddSchedule'
+          component={AddSchduleScreen}
+          options={{ headerShown: false }}
+        />
+        {/* <Stack.Screen
           name='SignIn'
           component={SignIn}
           options={{ headerShown: false }}
@@ -75,7 +81,7 @@ const App = () => {
           name='MeetSearch'
           component={MeetSearchSreen}
           options={{ headerShown: false }}
-        />
+        /> */}
       </Stack.Navigator>
       <StatusBar style='auto' />
     </NavigationContainer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ModifyNotiScreen from './screens/ModifyNotiScreen';
 import MeetSearchSreen from './screens/MeetSearchScreen';
 import { RootStackParamList } from './types';
 import AddSchduleScreen from './screens/AddScheduleScreen';
+import HomeScreen from './screens/HomeScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -27,10 +28,19 @@ const App = () => {
           component={SplashScreen}
           options={{ headerShown: false }}
         /> */}
+        {/* <Stack.Screen
+          name='TempHome'
+          component={HomeScreen}
+          options={{ headerShown: false }}
+        /> */}
         <Stack.Screen
           name='AddSchedule'
           component={AddSchduleScreen}
-          options={{ headerShown: false }}
+          options={{
+            headerShown: false,
+            presentation: 'modal',
+            gestureDirection: 'vertical',
+          }}
         />
         {/* <Stack.Screen
           name='SignIn'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,26 +23,12 @@ const App = () => {
   return (
     <NavigationContainer>
       <Stack.Navigator>
-        {/* <Stack.Screen
+        <Stack.Screen
           name='Splash'
           component={SplashScreen}
           options={{ headerShown: false }}
-        /> */}
-        {/* <Stack.Screen
-          name='TempHome'
-          component={HomeScreen}
-          options={{ headerShown: false }}
-        /> */}
-        <Stack.Screen
-          name='AddSchedule'
-          component={AddSchduleScreen}
-          options={{
-            headerShown: false,
-            presentation: 'modal',
-            gestureDirection: 'vertical',
-          }}
         />
-        {/* <Stack.Screen
+        <Stack.Screen
           name='SignIn'
           component={SignIn}
           options={{ headerShown: false }}
@@ -91,7 +77,16 @@ const App = () => {
           name='MeetSearch'
           component={MeetSearchSreen}
           options={{ headerShown: false }}
-        /> */}
+        />
+        <Stack.Screen
+          name='AddSchedule'
+          component={AddSchduleScreen}
+          options={{
+            headerShown: false,
+            presentation: 'modal',
+            gestureDirection: 'vertical',
+          }}
+        />
       </Stack.Navigator>
       <StatusBar style='auto' />
     </NavigationContainer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import ModifyNotiScreen from './screens/ModifyNotiScreen';
 import MeetSearchSreen from './screens/MeetSearchScreen';
 import { RootStackParamList } from './types';
 import AddSchduleScreen from './screens/AddScheduleScreen';
-import HomeScreen from './screens/HomeScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -113,39 +113,51 @@ const AddSchduleScreen = () => {
           <View style={[styles.innerScheduleBox, styles.timeBox]}>
             <Text style={styles.mainScheduleInfoText}>시작 시간</Text>
             {Platform.OS === 'ios' && (
-              <DateTimePicker
-                value={startTime}
-                mode='time'
-                minuteInterval={10}
-                accentColor='#FA1F11'
-              />
-            )}
-            {Platform.OS === 'android' && (
               <>
-                <TouchableOpacity
-                  style={styles.androidTimePicker}
-                  onPress={onPressStartTime}
-                >
-                  <Text
-                    style={[
-                      styles.androidTimePickerText,
-                      isStartTimeTouched && styles.androidAccentColor,
-                    ]}
-                  >
-                    {startTime.toLocaleTimeString('ko-KR', {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                  </Text>
-                </TouchableOpacity>
-                {startTimeOpen && (
+                {isEnabled ? (
+                  <View style={styles.iOSTimeBlock} />
+                ) : (
                   <DateTimePicker
                     value={startTime}
                     mode='time'
                     minuteInterval={10}
-                    display='spinner'
-                    onChange={(event, date) => handleStartChange(date)}
+                    accentColor='#FA1F11'
                   />
+                )}
+              </>
+            )}
+            {Platform.OS === 'android' && (
+              <>
+                {isEnabled ? (
+                  <View style={styles.androidTimeBlock} />
+                ) : (
+                  <>
+                    <TouchableOpacity
+                      style={styles.androidTimePicker}
+                      onPress={onPressStartTime}
+                    >
+                      <Text
+                        style={[
+                          styles.androidTimePickerText,
+                          isStartTimeTouched && styles.androidAccentColor,
+                        ]}
+                      >
+                        {startTime.toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </Text>
+                    </TouchableOpacity>
+                    {startTimeOpen && (
+                      <DateTimePicker
+                        value={startTime}
+                        mode='time'
+                        minuteInterval={10}
+                        display='spinner'
+                        onChange={(event, date) => handleStartChange(date)}
+                      />
+                    )}
+                  </>
                 )}
               </>
             )}
@@ -155,39 +167,51 @@ const AddSchduleScreen = () => {
           >
             <Text style={styles.mainScheduleInfoText}>종료 시간</Text>
             {Platform.OS === 'ios' && (
-              <DateTimePicker
-                value={finishTime}
-                mode='time'
-                minuteInterval={10}
-                accentColor='#FA1F11'
-              />
-            )}
-            {Platform.OS === 'android' && (
               <>
-                <TouchableOpacity
-                  style={styles.androidTimePicker}
-                  onPress={onPressFinishTime}
-                >
-                  <Text
-                    style={[
-                      styles.androidTimePickerText,
-                      isFinishTimeTouched && styles.androidAccentColor,
-                    ]}
-                  >
-                    {finishTime.toLocaleTimeString('ko-KR', {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                  </Text>
-                </TouchableOpacity>
-                {finishTimeOpen && (
+                {isEnabled ? (
+                  <View style={styles.iOSTimeBlock} />
+                ) : (
                   <DateTimePicker
                     value={finishTime}
                     mode='time'
                     minuteInterval={10}
-                    display='spinner'
-                    onChange={(event, date) => handleFinishChange(date)}
+                    accentColor='#FA1F11'
                   />
+                )}
+              </>
+            )}
+            {Platform.OS === 'android' && (
+              <>
+                {isEnabled ? (
+                  <View style={styles.androidTimeBlock} />
+                ) : (
+                  <>
+                    <TouchableOpacity
+                      style={styles.androidTimePicker}
+                      onPress={onPressFinishTime}
+                    >
+                      <Text
+                        style={[
+                          styles.androidTimePickerText,
+                          isFinishTimeTouched && styles.androidAccentColor,
+                        ]}
+                      >
+                        {finishTime.toLocaleTimeString('ko-KR', {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </Text>
+                    </TouchableOpacity>
+                    {finishTimeOpen && (
+                      <DateTimePicker
+                        value={finishTime}
+                        mode='time'
+                        minuteInterval={10}
+                        display='spinner'
+                        onChange={(event, date) => handleFinishChange(date)}
+                      />
+                    )}
+                  </>
                 )}
               </>
             )}
@@ -282,6 +306,18 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  iOSTimeBlock: {
+    width: 93,
+    height: 35,
+    borderRadius: 5,
+    backgroundColor: '#EBEBF0',
+  },
+  androidTimeBlock: {
+    width: 90,
+    height: 30,
+    borderRadius: 5,
+    backgroundColor: '#EBEBF0',
   },
   androidTimePicker: {
     width: 90,

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -19,6 +19,8 @@ const AddSchduleScreen = () => {
   const [finishTime, setFinishTime] = useState<Date>(new Date());
   const [startTimeOpen, setStartTimeOpen] = useState(false);
   const [finishTimeOpen, setFinishTimeOpen] = useState(false);
+  const [isStartTimeTouched, setIsStartTimeTouched] = useState(false);
+  const [isFinishTimeTouched, setIsFinishTimeTouched] = useState(false);
   const [selected, setSelected] = useState(undefined);
   const toggleSwitch = () => setIsEnabled(!isEnabled);
 
@@ -30,6 +32,7 @@ const AddSchduleScreen = () => {
   ];
 
   const onPressStartTime = () => {
+    Platform.OS === 'android' && setIsStartTimeTouched(!isStartTimeTouched);
     setStartTimeOpen(!startTimeOpen);
     if (finishTimeOpen) {
       setFinishTimeOpen(!finishTimeOpen);
@@ -37,6 +40,7 @@ const AddSchduleScreen = () => {
   };
 
   const onPressFinishTime = () => {
+    Platform.OS === 'android' && setIsFinishTimeTouched(!isFinishTimeTouched);
     setFinishTimeOpen(!finishTimeOpen);
     if (startTimeOpen) {
       setStartTimeOpen(!startTimeOpen);
@@ -49,6 +53,7 @@ const AddSchduleScreen = () => {
       return;
     }
     setStartTime(date);
+    Platform.OS === 'android' && setIsStartTimeTouched(!isStartTimeTouched);
   };
 
   const handleFinishChange = (date: Date | undefined) => {
@@ -57,6 +62,7 @@ const AddSchduleScreen = () => {
       return;
     }
     setFinishTime(date);
+    Platform.OS === 'android' && setIsFinishTimeTouched(!isFinishTimeTouched);
   };
 
   return (
@@ -120,7 +126,12 @@ const AddSchduleScreen = () => {
                   style={styles.androidTimePicker}
                   onPress={onPressStartTime}
                 >
-                  <Text style={styles.androidTimePickerText}>
+                  <Text
+                    style={[
+                      styles.androidTimePickerText,
+                      isStartTimeTouched && styles.androidAccentColor,
+                    ]}
+                  >
                     {startTime.toLocaleTimeString('ko-KR', {
                       hour: '2-digit',
                       minute: '2-digit',
@@ -157,7 +168,12 @@ const AddSchduleScreen = () => {
                   style={styles.androidTimePicker}
                   onPress={onPressFinishTime}
                 >
-                  <Text style={styles.androidTimePickerText}>
+                  <Text
+                    style={[
+                      styles.androidTimePickerText,
+                      isFinishTimeTouched && styles.androidAccentColor,
+                    ]}
+                  >
                     {finishTime.toLocaleTimeString('ko-KR', {
                       hour: '2-digit',
                       minute: '2-digit',
@@ -279,6 +295,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#000000',
     lineHeight: 19,
+  },
+  androidAccentColor: {
+    color: '#FA1F11',
   },
   notiSettingBox: {
     width: '85%',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -7,9 +7,9 @@ import {
   TextInput,
   Switch,
   Platform,
+  StatusBar,
 } from 'react-native';
 import { useState } from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
 
@@ -74,7 +74,10 @@ const AddSchduleScreen = () => {
   };
 
   return (
-    <SafeAreaView style={styles.mainContainer} edges={['top']}>
+    <View style={styles.mainContainer}>
+      {Platform.OS === 'android' && (
+        <StatusBar backgroundColor='black' barStyle={'default'} />
+      )}
       <View style={styles.topBar}>
         <TouchableOpacity>
           <Text style={styles.topBarText}>취소</Text>
@@ -261,15 +264,15 @@ const AddSchduleScreen = () => {
           />
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
   mainContainer: {
     flex: 1,
-    height: '100%',
-    backgroundColor: '#5496FF',
+    paddingTop: Platform.OS === 'ios' ? 0 : StatusBar.currentHeight,
+    backgroundColor: Platform.OS === 'android' ? 'black' : '#F5F5F5',
   },
   topBar: {
     backgroundColor: '#5496FF',
@@ -277,6 +280,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     height: 50,
     alignItems: 'center',
+    borderTopLeftRadius: 5,
+    borderTopRightRadius: 5,
   },
   topBarText: {
     color: '#FFFFFF',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -9,12 +9,14 @@ import {
   Platform,
   StatusBar,
   Alert,
+  KeyboardAvoidingView,
 } from 'react-native';
 import { useState } from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
 import { useNavigation } from '@react-navigation/native';
 import { NavigationProp } from '../types';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const AddSchduleScreen = () => {
   const [title, setTitle] = useState('');
@@ -33,7 +35,7 @@ const AddSchduleScreen = () => {
 
   const [selected, setSelected] = useState(undefined);
 
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(true);
 
   const toggleSwitch = () => setIsEnabled(!isEnabled);
   const navigation = useNavigation<NavigationProp>();
@@ -90,7 +92,7 @@ const AddSchduleScreen = () => {
   };
 
   return (
-    <View style={styles.mainContainer}>
+    <SafeAreaView style={styles.mainContainer} edges={['bottom']}>
       {Platform.OS === 'android' && (
         <StatusBar backgroundColor='black' barStyle={'default'} />
       )}
@@ -272,15 +274,22 @@ const AddSchduleScreen = () => {
             selectedRowTextStyle={styles.notiSelectedText}
           />
         </View>
-        <View style={[styles.descriptionBox, styles.innerMaginTop]}>
-          <TextInput
-            style={styles.descriptionInput}
-            placeholder='설명'
-            placeholderTextColor={'#878787'}
-            maxLength={150}
-            multiline={true}
-          />
-        </View>
+        <KeyboardAvoidingView
+          behavior={Platform.select({ ios: 'padding' })}
+          keyboardVerticalOffset={Platform.select({ ios: 100 })}
+          style={{ flex: 1 }}
+        >
+          <View style={[styles.descriptionBox, styles.innerMaginTop]}>
+            <TextInput
+              style={styles.descriptionInput}
+              placeholder='설명'
+              placeholderTextColor={'#878787'}
+              maxLength={150}
+              multiline={true}
+              numberOfLines={6}
+            />
+          </View>
+        </KeyboardAvoidingView>
         {isEditing && (
           <TouchableOpacity
             style={styles.deleteButton}
@@ -290,7 +299,7 @@ const AddSchduleScreen = () => {
           </TouchableOpacity>
         )}
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -358,7 +367,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   iOSTimeBlock: {
-    width: 93,
+    width: 70,
     height: 35,
     borderRadius: 5,
     backgroundColor: '#EBEBF0',
@@ -432,6 +441,7 @@ const styles = StyleSheet.create({
   descriptionInput: {
     fontSize: 16,
     lineHeight: 20,
+    textAlignVertical: 'top',
   },
   deleteButton: {
     width: '90%',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -14,14 +14,22 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
 
 const AddSchduleScreen = () => {
+  const [title, setTitle] = useState('');
+  const [isDisabled, setIsDisabled] = useState(true);
+
   const [isEnabled, setIsEnabled] = useState(false);
+
   const [startTime, setStartTime] = useState<Date>(new Date());
   const [finishTime, setFinishTime] = useState<Date>(new Date());
+
+  // 안드로이드 커스텀용
   const [startTimeOpen, setStartTimeOpen] = useState(false);
   const [finishTimeOpen, setFinishTimeOpen] = useState(false);
   const [isStartTimeTouched, setIsStartTimeTouched] = useState(false);
   const [isFinishTimeTouched, setIsFinishTimeTouched] = useState(false);
+
   const [selected, setSelected] = useState(undefined);
+
   const toggleSwitch = () => setIsEnabled(!isEnabled);
 
   const notiType = [
@@ -72,8 +80,12 @@ const AddSchduleScreen = () => {
           <Text style={styles.topBarText}>취소</Text>
         </TouchableOpacity>
         <Text style={[styles.topBarText, styles.topBarTitle]}>새로운 일정</Text>
-        <TouchableOpacity>
-          <Text style={styles.topBarText}>추가</Text>
+        <TouchableOpacity disabled={isDisabled}>
+          <Text
+            style={[styles.topBarText, !title ? styles.disabledAddText : null]}
+          >
+            추가
+          </Text>
         </TouchableOpacity>
       </View>
       <ScrollView style={styles.mainView}>
@@ -82,7 +94,13 @@ const AddSchduleScreen = () => {
             <TextInput
               style={styles.mainScheduleInfoText}
               placeholder='제목'
+              value={title}
+              onChangeText={text => {
+                text ? setIsDisabled(false) : setIsDisabled(true);
+                setTitle(text);
+              }}
               placeholderTextColor={'#878787'}
+              autoFocus // 제목 value가 null일 때만
             />
           </View>
           <View style={styles.innerScheduleBox}>
@@ -270,6 +288,9 @@ const styles = StyleSheet.create({
   topBarTitle: {
     fontWeight: '600',
   },
+  disabledAddText: {
+    color: 'rgba(255, 255, 255, 0.5)',
+  },
   mainView: {
     backgroundColor: '#F5F5F5',
   },
@@ -290,9 +311,7 @@ const styles = StyleSheet.create({
   noneBorder: {
     borderBottomWidth: 0,
   },
-  innerMaginTop: {
-    marginTop: 20,
-  },
+  innerMaginTop: { marginTop: 30 },
   mainScheduleInfoText: {
     color: '#000000',
     fontSize: 16,

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -1,0 +1,167 @@
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  Switch,
+} from 'react-native';
+import { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const AddSchduleScreen = () => {
+  const [isEnabled, setIsEnabled] = useState(false);
+  const toggleSwitch = () => setIsEnabled(!isEnabled);
+
+  return (
+    <SafeAreaView style={styles.mainContainer} edges={['top']}>
+      <View style={styles.topBar}>
+        <TouchableOpacity>
+          <Text style={styles.topBarText}>취소</Text>
+        </TouchableOpacity>
+        <Text style={[styles.topBarText, styles.topBarTitle]}>새로운 일정</Text>
+        <TouchableOpacity>
+          <Text style={styles.topBarText}>추가</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView style={styles.mainView}>
+        <View style={styles.mainScheduleInfoBox}>
+          <View style={styles.innerScheduleBox}>
+            <TextInput
+              style={styles.mainScheduleInfoText}
+              placeholder='제목'
+              placeholderTextColor={'#878787'}
+            />
+          </View>
+          <View style={styles.innerScheduleBox}>
+            {/* 날짜 부분은 추후 Text 컴포넌트로 변경 및 props로 받아올 것 */}
+            <TextInput
+              style={styles.mainScheduleInfoText}
+              placeholder='날짜'
+              placeholderTextColor={'#878787'}
+            />
+          </View>
+          <View style={[styles.innerScheduleBox, styles.noneBorder]}>
+            <TextInput
+              style={styles.mainScheduleInfoText}
+              placeholder='장소'
+              placeholderTextColor={'#878787'}
+            />
+          </View>
+        </View>
+        <View style={[styles.mainScheduleInfoBox, styles.innerMaginTop]}>
+          <View style={[styles.innerScheduleBox, styles.switchBox]}>
+            <Text style={styles.mainScheduleInfoText}>하루 종일</Text>
+            <Switch
+              trackColor={{ false: '#D1D1D6', true: '##D1D1D6' }}
+              onValueChange={toggleSwitch}
+              value={isEnabled}
+            />
+          </View>
+          <View style={styles.innerScheduleBox}>
+            <Text style={styles.mainScheduleInfoText}>시작 시간</Text>
+          </View>
+          <View style={[styles.innerScheduleBox, styles.noneBorder]}>
+            <Text style={styles.mainScheduleInfoText}>종료 시간</Text>
+          </View>
+        </View>
+        <View style={[styles.notiSettingBox, styles.innerMaginTop]}>
+          <Text style={styles.notiSettingText}>알림</Text>
+        </View>
+        <View style={[styles.descriptionBox, styles.innerMaginTop]}>
+          <TextInput
+            style={styles.descriptionInput}
+            placeholder='설명'
+            placeholderTextColor={'#878787'}
+            maxLength={150}
+            multiline={true}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1,
+    height: '100%',
+    backgroundColor: '#5496FF',
+  },
+  topBar: {
+    backgroundColor: '#5496FF',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    height: 50,
+    alignItems: 'center',
+  },
+  topBarText: {
+    color: '#ffffff',
+    fontSize: 20,
+    lineHeight: 30,
+    fontWeight: '500',
+    marginHorizontal: 15,
+  },
+  topBarTitle: {
+    fontWeight: '600',
+  },
+  mainView: {
+    backgroundColor: '#F5F5F5',
+  },
+  mainScheduleInfoBox: {
+    backgroundColor: '#ffffff',
+    borderRadius: 10,
+    width: '85%',
+    height: 120,
+    alignSelf: 'center',
+    paddingHorizontal: 10,
+    marginTop: 30,
+  },
+  innerScheduleBox: {
+    borderBottomWidth: 1,
+    borderColor: '#c6c6c6',
+    height: 40,
+    justifyContent: 'center',
+  },
+  noneBorder: {
+    borderBottomWidth: 0,
+  },
+  innerMaginTop: {
+    marginTop: 20,
+  },
+  mainScheduleInfoText: {
+    color: '#000000',
+    fontSize: 16,
+  },
+  switchBox: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  notiSettingBox: {
+    width: '85%',
+    height: 40,
+    backgroundColor: '#ffffff',
+    alignSelf: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 15,
+    borderRadius: 10,
+  },
+  notiSettingText: { fontSize: 16 },
+  descriptionBox: {
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 15,
+    paddingVertical: 10,
+    width: '85%',
+    height: 160,
+    borderRadius: 10,
+    alignSelf: 'center',
+  },
+  descriptionInput: {
+    fontSize: 16,
+    lineHeight: 20,
+  },
+});
+
+export default AddSchduleScreen;

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -6,29 +6,42 @@ import {
   ScrollView,
   TextInput,
   Switch,
-  Button,
+  Platform,
 } from 'react-native';
 import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import DateTimePicker, {
-  DateTimePickerAndroid,
-} from '@react-native-community/datetimepicker';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
 
 const AddSchduleScreen = () => {
   const [isEnabled, setIsEnabled] = useState(false);
   const [startTime, setStartTime] = useState(new Date());
   const [finishTime, setFinishTime] = useState(new Date());
-  //   DateTimePickerAndroid.open(params: AndroidNativeProps);
-  // DateTimePickerAndroid.dismiss(mode: AndroidNativeProps['mode']);
+  const [startTimeOpen, setStartTimeOpen] = useState(false);
+  const [finishTimeOpen, setFinishTimeOpen] = useState(false);
   const [selected, setSelected] = useState(undefined);
   const toggleSwitch = () => setIsEnabled(!isEnabled);
+
   const notiType = [
     '2일 전(오전 9시)',
     '1일 전(오전 9시)',
     '당일날(오전 9시)',
     '없음',
   ];
+
+  const onPressStartTime = () => {
+    if (finishTimeOpen) {
+      setFinishTimeOpen(!finishTimeOpen);
+    }
+    setStartTimeOpen(!startTimeOpen);
+  };
+
+  const onPressFinishTime = () => {
+    if (startTimeOpen) {
+      setStartTimeOpen(!startTimeOpen);
+    }
+    setFinishTimeOpen(!finishTimeOpen);
+  };
 
   return (
     <SafeAreaView style={styles.mainContainer} edges={['top']}>
@@ -77,17 +90,71 @@ const AddSchduleScreen = () => {
           </View>
           <View style={[styles.innerScheduleBox, styles.timeBox]}>
             <Text style={styles.mainScheduleInfoText}>시작 시간</Text>
-            <DateTimePicker value={startTime} mode='time' minuteInterval={10} />
+            {Platform.OS === 'ios' && (
+              <DateTimePicker
+                value={startTime}
+                mode='time'
+                minuteInterval={10}
+              />
+            )}
+            {Platform.OS === 'android' && (
+              <>
+                <TouchableOpacity
+                  style={styles.androidTimePicker}
+                  onPress={onPressStartTime}
+                >
+                  <Text style={styles.androidTimePickerText}>
+                    {startTime.toLocaleTimeString('ko-KR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </Text>
+                </TouchableOpacity>
+                {startTimeOpen && (
+                  <DateTimePicker
+                    value={startTime}
+                    mode='time'
+                    minuteInterval={10}
+                    display='spinner'
+                  />
+                )}
+              </>
+            )}
           </View>
           <View
             style={[styles.innerScheduleBox, styles.noneBorder, styles.timeBox]}
           >
             <Text style={styles.mainScheduleInfoText}>종료 시간</Text>
-            <DateTimePicker
-              value={finishTime}
-              mode='time'
-              minuteInterval={10}
-            />
+            {Platform.OS === 'ios' && (
+              <DateTimePicker
+                value={startTime}
+                mode='time'
+                minuteInterval={10}
+              />
+            )}
+            {Platform.OS === 'android' && (
+              <>
+                <TouchableOpacity
+                  style={styles.androidTimePicker}
+                  onPress={onPressFinishTime}
+                >
+                  <Text style={styles.androidTimePickerText}>
+                    {finishTime.toLocaleTimeString('ko-KR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </Text>
+                </TouchableOpacity>
+                {finishTimeOpen && (
+                  <DateTimePicker
+                    value={finishTime}
+                    mode='time'
+                    minuteInterval={10}
+                    display='spinner'
+                  />
+                )}
+              </>
+            )}
           </View>
         </View>
         <View style={[styles.notiSettingBox, styles.innerMaginTop]}>
@@ -177,6 +244,19 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  androidTimePicker: {
+    width: 90,
+    height: 30,
+    backgroundColor: '#EBEBF0',
+    borderRadius: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  androidTimePickerText: {
+    fontSize: 16,
+    color: '#000000',
+    lineHeight: 19,
   },
   notiSettingBox: {
     width: '85%',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -127,7 +127,7 @@ const AddSchduleScreen = () => {
             <Text style={styles.mainScheduleInfoText}>종료 시간</Text>
             {Platform.OS === 'ios' && (
               <DateTimePicker
-                value={startTime}
+                value={finishTime}
                 mode='time'
                 minuteInterval={10}
               />

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -23,10 +23,10 @@ const AddSchduleScreen = () => {
   const toggleSwitch = () => setIsEnabled(!isEnabled);
 
   const notiType = [
-    '2일 전(오전 9시)',
-    '1일 전(오전 9시)',
-    '당일날(오전 9시)',
     '없음',
+    '당일날(오전 9시)',
+    '1일 전(오전 9시)',
+    '2일 전(오전 9시)',
   ];
 
   const onPressStartTime = () => {
@@ -111,6 +111,7 @@ const AddSchduleScreen = () => {
                 value={startTime}
                 mode='time'
                 minuteInterval={10}
+                accentColor='#FA1F11'
               />
             )}
             {Platform.OS === 'android' && (
@@ -147,6 +148,7 @@ const AddSchduleScreen = () => {
                 value={finishTime}
                 mode='time'
                 minuteInterval={10}
+                accentColor='#FA1F11'
               />
             )}
             {Platform.OS === 'android' && (
@@ -180,13 +182,15 @@ const AddSchduleScreen = () => {
           <SelectDropdown
             data={notiType}
             onSelect={setSelected}
-            defaultButtonText='없음'
-            defaultValueByIndex={3}
+            defaultButtonText={notiType[0]}
+            defaultValueByIndex={0}
             statusBarTranslucent={true}
             buttonStyle={styles.notiSelectBox}
             buttonTextStyle={styles.notiSelectText}
             dropdownStyle={styles.notiDropDownBox}
-            selectedRowTextStyle={{ fontWeight: '600', color: '#5496FF' }} //임시 스타일이라 인라인 처리 합니다.
+            rowStyle={styles.notiDropDownItemBox}
+            rowTextStyle={styles.notiDropDownItemText}
+            selectedRowTextStyle={styles.notiSelectedText}
           />
         </View>
         <View style={[styles.descriptionBox, styles.innerMaginTop]}>
@@ -294,11 +298,22 @@ const styles = StyleSheet.create({
   },
   notiDropDownBox: {
     borderRadius: 10,
-    width: 200,
+    width: 220,
   },
   notiSelectText: {
     fontSize: 16,
     color: '#878787',
+    textAlign: 'right',
+  },
+  notiSelectedText: {
+    color: '#5496FF',
+  },
+  notiDropDownItemBox: {
+    height: 45,
+  },
+  notiDropDownItemText: {
+    textAlign: 'left',
+    marginLeft: 35,
   },
   descriptionBox: {
     backgroundColor: '#FFFFFF',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -8,10 +8,13 @@ import {
   Switch,
   Platform,
   StatusBar,
+  Alert,
 } from 'react-native';
 import { useState } from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
+import { useNavigation } from '@react-navigation/native';
+import { NavigationProp } from '../types';
 
 const AddSchduleScreen = () => {
   const [title, setTitle] = useState('');
@@ -30,7 +33,10 @@ const AddSchduleScreen = () => {
 
   const [selected, setSelected] = useState(undefined);
 
+  const [isEditing, setIsEditing] = useState(false);
+
   const toggleSwitch = () => setIsEnabled(!isEnabled);
+  const navigation = useNavigation<NavigationProp>();
 
   const notiType = [
     '없음',
@@ -73,21 +79,33 @@ const AddSchduleScreen = () => {
     Platform.OS === 'android' && setIsFinishTimeTouched(!isFinishTimeTouched);
   };
 
+  const deleteButtonPress = () => {
+    Alert.alert('', title + '일정을 삭제하겠습니까?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        style: 'destructive',
+      },
+    ]);
+  };
+
   return (
     <View style={styles.mainContainer}>
       {Platform.OS === 'android' && (
         <StatusBar backgroundColor='black' barStyle={'default'} />
       )}
       <View style={styles.topBar}>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.pop()}>
           <Text style={styles.topBarText}>취소</Text>
         </TouchableOpacity>
-        <Text style={[styles.topBarText, styles.topBarTitle]}>새로운 일정</Text>
+        <Text style={[styles.topBarText, styles.topBarTitle]}>
+          {isEditing ? '일정 편집' : '새로운 일정'}
+        </Text>
         <TouchableOpacity disabled={isDisabled}>
           <Text
             style={[styles.topBarText, !title ? styles.disabledAddText : null]}
           >
-            추가
+            {isEditing ? '완료' : '추가'}
           </Text>
         </TouchableOpacity>
       </View>
@@ -263,6 +281,14 @@ const AddSchduleScreen = () => {
             multiline={true}
           />
         </View>
+        {isEditing && (
+          <TouchableOpacity
+            style={styles.deleteButton}
+            onPress={deleteButtonPress}
+          >
+            <Text style={styles.deleteButtonText}>일정 삭제</Text>
+          </TouchableOpacity>
+        )}
       </ScrollView>
     </View>
   );
@@ -406,6 +432,21 @@ const styles = StyleSheet.create({
   descriptionInput: {
     fontSize: 16,
     lineHeight: 20,
+  },
+  deleteButton: {
+    width: '90%',
+    alignSelf: 'center',
+    height: 56,
+    backgroundColor: '#FFFFFF',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 14,
+    marginTop: 124,
+  },
+  deleteButtonText: {
+    color: '#FA1F11',
+    fontSize: 17,
+    lineHeight: 22,
   },
 });
 

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -6,13 +6,21 @@ import {
   ScrollView,
   TextInput,
   Switch,
+  Button,
 } from 'react-native';
 import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import DateTimePicker, {
+  DateTimePickerAndroid,
+} from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
 
 const AddSchduleScreen = () => {
   const [isEnabled, setIsEnabled] = useState(false);
+  const [startTime, setStartTime] = useState(new Date());
+  const [finishTime, setFinishTime] = useState(new Date());
+  //   DateTimePickerAndroid.open(params: AndroidNativeProps);
+  // DateTimePickerAndroid.dismiss(mode: AndroidNativeProps['mode']);
   const [selected, setSelected] = useState(undefined);
   const toggleSwitch = () => setIsEnabled(!isEnabled);
   const notiType = [
@@ -67,11 +75,19 @@ const AddSchduleScreen = () => {
               value={isEnabled}
             />
           </View>
-          <View style={styles.innerScheduleBox}>
+          <View style={[styles.innerScheduleBox, styles.timeBox]}>
             <Text style={styles.mainScheduleInfoText}>시작 시간</Text>
+            <DateTimePicker value={startTime} mode='time' minuteInterval={10} />
           </View>
-          <View style={[styles.innerScheduleBox, styles.noneBorder]}>
+          <View
+            style={[styles.innerScheduleBox, styles.noneBorder, styles.timeBox]}
+          >
             <Text style={styles.mainScheduleInfoText}>종료 시간</Text>
+            <DateTimePicker
+              value={finishTime}
+              mode='time'
+              minuteInterval={10}
+            />
           </View>
         </View>
         <View style={[styles.notiSettingBox, styles.innerMaginTop]}>
@@ -132,7 +148,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     borderRadius: 10,
     width: '85%',
-    height: 120,
     alignSelf: 'center',
     paddingHorizontal: 10,
     marginTop: 30,
@@ -157,6 +172,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  timeBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
   notiSettingBox: {
     width: '85%',

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -12,7 +12,6 @@ import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
-import { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 const AddSchduleScreen = () => {
   const [isEnabled, setIsEnabled] = useState(false);
@@ -44,10 +43,7 @@ const AddSchduleScreen = () => {
     }
   };
 
-  const handleStartChange = (
-    event: DateTimePickerEvent,
-    date: Date | undefined
-  ) => {
+  const handleStartChange = (date: Date | undefined) => {
     setStartTimeOpen(!setStartTimeOpen);
     if (!date) {
       return;
@@ -55,10 +51,7 @@ const AddSchduleScreen = () => {
     setStartTime(date);
   };
 
-  const handleFinishChange = (
-    event: DateTimePickerEvent,
-    date: Date | undefined
-  ) => {
+  const handleFinishChange = (date: Date | undefined) => {
     setFinishTimeOpen(!setFinishTimeOpen);
     if (!date) {
       return;
@@ -139,7 +132,7 @@ const AddSchduleScreen = () => {
                     mode='time'
                     minuteInterval={10}
                     display='spinner'
-                    onChange={(event, date) => handleStartChange(event, date)}
+                    onChange={(event, date) => handleStartChange(date)}
                   />
                 )}
               </>
@@ -175,7 +168,7 @@ const AddSchduleScreen = () => {
                     mode='time'
                     minuteInterval={10}
                     display='spinner'
-                    onChange={(event, date) => handleFinishChange(event, date)}
+                    onChange={(event, date) => handleFinishChange(date)}
                   />
                 )}
               </>

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -9,10 +9,18 @@ import {
 } from 'react-native';
 import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import SelectDropdown from 'react-native-select-dropdown';
 
 const AddSchduleScreen = () => {
   const [isEnabled, setIsEnabled] = useState(false);
+  const [selected, setSelected] = useState(undefined);
   const toggleSwitch = () => setIsEnabled(!isEnabled);
+  const notiType = [
+    '2일 전(오전 9시)',
+    '1일 전(오전 9시)',
+    '당일날(오전 9시)',
+    '없음',
+  ];
 
   return (
     <SafeAreaView style={styles.mainContainer} edges={['top']}>
@@ -68,6 +76,17 @@ const AddSchduleScreen = () => {
         </View>
         <View style={[styles.notiSettingBox, styles.innerMaginTop]}>
           <Text style={styles.notiSettingText}>알림</Text>
+          <SelectDropdown
+            data={notiType}
+            onSelect={setSelected}
+            defaultButtonText='없음'
+            defaultValueByIndex={3}
+            statusBarTranslucent={true}
+            buttonStyle={styles.notiSelectBox}
+            buttonTextStyle={styles.notiSelectText}
+            dropdownStyle={styles.notiDropDownBox}
+            selectedRowTextStyle={{ fontWeight: '600', color: '#5496FF' }} //임시 스타일이라 인라인 처리 합니다.
+          />
         </View>
         <View style={[styles.descriptionBox, styles.innerMaginTop]}>
           <TextInput
@@ -144,11 +163,25 @@ const styles = StyleSheet.create({
     height: 40,
     backgroundColor: '#ffffff',
     alignSelf: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     paddingHorizontal: 15,
     borderRadius: 10,
+    flexDirection: 'row',
   },
   notiSettingText: { fontSize: 16 },
+  notiSelectBox: {
+    backgroundColor: '#ffffff',
+    height: 30,
+  },
+  notiDropDownBox: {
+    borderRadius: 10,
+    width: 200,
+  },
+  notiSelectText: {
+    fontSize: 16,
+    color: '#878787',
+  },
   descriptionBox: {
     backgroundColor: '#ffffff',
     paddingHorizontal: 15,

--- a/src/screens/AddScheduleScreen.tsx
+++ b/src/screens/AddScheduleScreen.tsx
@@ -12,11 +12,12 @@ import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SelectDropdown from 'react-native-select-dropdown';
+import { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 const AddSchduleScreen = () => {
   const [isEnabled, setIsEnabled] = useState(false);
-  const [startTime, setStartTime] = useState(new Date());
-  const [finishTime, setFinishTime] = useState(new Date());
+  const [startTime, setStartTime] = useState<Date>(new Date());
+  const [finishTime, setFinishTime] = useState<Date>(new Date());
   const [startTimeOpen, setStartTimeOpen] = useState(false);
   const [finishTimeOpen, setFinishTimeOpen] = useState(false);
   const [selected, setSelected] = useState(undefined);
@@ -30,17 +31,39 @@ const AddSchduleScreen = () => {
   ];
 
   const onPressStartTime = () => {
+    setStartTimeOpen(!startTimeOpen);
     if (finishTimeOpen) {
       setFinishTimeOpen(!finishTimeOpen);
     }
-    setStartTimeOpen(!startTimeOpen);
   };
 
   const onPressFinishTime = () => {
+    setFinishTimeOpen(!finishTimeOpen);
     if (startTimeOpen) {
       setStartTimeOpen(!startTimeOpen);
     }
-    setFinishTimeOpen(!finishTimeOpen);
+  };
+
+  const handleStartChange = (
+    event: DateTimePickerEvent,
+    date: Date | undefined
+  ) => {
+    setStartTimeOpen(!setStartTimeOpen);
+    if (!date) {
+      return;
+    }
+    setStartTime(date);
+  };
+
+  const handleFinishChange = (
+    event: DateTimePickerEvent,
+    date: Date | undefined
+  ) => {
+    setFinishTimeOpen(!setFinishTimeOpen);
+    if (!date) {
+      return;
+    }
+    setFinishTime(date);
   };
 
   return (
@@ -116,6 +139,7 @@ const AddSchduleScreen = () => {
                     mode='time'
                     minuteInterval={10}
                     display='spinner'
+                    onChange={(event, date) => handleStartChange(event, date)}
                   />
                 )}
               </>
@@ -151,6 +175,7 @@ const AddSchduleScreen = () => {
                     mode='time'
                     minuteInterval={10}
                     display='spinner'
+                    onChange={(event, date) => handleFinishChange(event, date)}
                   />
                 )}
               </>
@@ -199,7 +224,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   topBarText: {
-    color: '#ffffff',
+    color: '#FFFFFF',
     fontSize: 20,
     lineHeight: 30,
     fontWeight: '500',
@@ -212,7 +237,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F5F5F5',
   },
   mainScheduleInfoBox: {
-    backgroundColor: '#ffffff',
+    backgroundColor: '#FFFFFF',
     borderRadius: 10,
     width: '85%',
     alignSelf: 'center',
@@ -221,7 +246,7 @@ const styles = StyleSheet.create({
   },
   innerScheduleBox: {
     borderBottomWidth: 1,
-    borderColor: '#c6c6c6',
+    borderColor: '#C6C6C6',
     height: 40,
     justifyContent: 'center',
   },
@@ -261,7 +286,7 @@ const styles = StyleSheet.create({
   notiSettingBox: {
     width: '85%',
     height: 40,
-    backgroundColor: '#ffffff',
+    backgroundColor: '#FFFFFF',
     alignSelf: 'center',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -271,7 +296,7 @@ const styles = StyleSheet.create({
   },
   notiSettingText: { fontSize: 16 },
   notiSelectBox: {
-    backgroundColor: '#ffffff',
+    backgroundColor: '#FFFFFF',
     height: 30,
   },
   notiDropDownBox: {
@@ -283,7 +308,7 @@ const styles = StyleSheet.create({
     color: '#878787',
   },
   descriptionBox: {
-    backgroundColor: '#ffffff',
+    backgroundColor: '#FFFFFF',
     paddingHorizontal: 15,
     paddingVertical: 10,
     width: '85%',

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,6 +3,9 @@ import { useState } from 'react';
 import { Calendar } from 'react-native-calendars';
 import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { BottomTabParamList } from '../types';
+import { Button } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NavigationProp } from '../types';
 
 type HomeScreenProps = BottomTabScreenProps<BottomTabParamList, 'Home'>;
 
@@ -10,6 +13,7 @@ const HomeScreen = ({ navigation }: HomeScreenProps) => {
   const [selectedDate, setSelectedDate] = useState('');
   const [currentMonth, setCurrentMonth] = useState('');
   const [schedule, setSchedule] = useState(false);
+  const tempNav = useNavigation<NavigationProp>();
 
   const handleDateSelect = (date: any) => {
     setSelectedDate(date.dateString);
@@ -73,6 +77,10 @@ const HomeScreen = ({ navigation }: HomeScreenProps) => {
           )}
         />
       </View>
+      <Button
+        title='바로가기'
+        onPress={() => tempNav.navigate('AddSchedule')}
+      />
       {schedule && (
         <View style={styles.scheduleContainer}>
           <View style={styles.scheduleBox}>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,9 +3,6 @@ import { useState } from 'react';
 import { Calendar } from 'react-native-calendars';
 import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { BottomTabParamList } from '../types';
-import { Button } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { NavigationProp } from '../types';
 
 type HomeScreenProps = BottomTabScreenProps<BottomTabParamList, 'Home'>;
 
@@ -13,7 +10,6 @@ const HomeScreen = ({ navigation }: HomeScreenProps) => {
   const [selectedDate, setSelectedDate] = useState('');
   const [currentMonth, setCurrentMonth] = useState('');
   const [schedule, setSchedule] = useState(false);
-  const tempNav = useNavigation<NavigationProp>();
 
   const handleDateSelect = (date: any) => {
     setSelectedDate(date.dateString);
@@ -77,10 +73,6 @@ const HomeScreen = ({ navigation }: HomeScreenProps) => {
           )}
         />
       </View>
-      <Button
-        title='바로가기'
-        onPress={() => tempNav.navigate('AddSchedule')}
-      />
       {schedule && (
         <View style={styles.scheduleContainer}>
           <View style={styles.scheduleBox}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type RootStackParamList = {
   };
   Splash: undefined;
   AddSchedule: undefined;
+  TempHome: undefined;
 };
 
 export type BottomTabParamList = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type RootStackParamList = {
     meetSearchText: string;
   };
   Splash: undefined;
+  AddSchedule: undefined;
 };
 
 export type BottomTabParamList = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,6 @@ export type RootStackParamList = {
   };
   Splash: undefined;
   AddSchedule: undefined;
-  TempHome: undefined;
 };
 
 export type BottomTabParamList = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,6 +1777,13 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
+"@react-native-community/datetimepicker@6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.7.3.tgz#e6d75a42729265d8404d1d668c86926564abca2f"
+  integrity sha512-fXWbEdHMLW/e8cts3snEsbOTbnFXfUHeO2pkiDFX3fWpFoDtUrRWvn50xbY13IJUUKHDhoJ+mj24nMRVIXfX1A==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6993,6 +6993,11 @@ react-native-safe-area-context@4.5.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz#9208313236e8f49e1920ac1e2a2c975f03aed284"
   integrity sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==
 
+react-native-select-dropdown@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-select-dropdown/-/react-native-select-dropdown-3.3.3.tgz#ecf240dd0d968f754522cdbf6f839c3c08e54114"
+  integrity sha512-mkekhWwe4EGk5d5jZ5ZdmPF5q87lkl3sZeO4Kojb+J8fBeYJS/zVcYeECqiBPBL3nZ4x/FEOAZlP8lbn3l2ptw==
+
 react-native-shadow-2@^7.0.7:
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/react-native-shadow-2/-/react-native-shadow-2-7.0.7.tgz#f83ac2dda5ac202281d9a06cdb239d9c8829e7d2"


### PR DESCRIPTION
최종 작업본 데모 영상 및 실 구현 스샷
**_1. 일정 추가_**
<img width="869" alt="Screenshot 2023-05-28 at 5 38 49 PM" src="https://github.com/mju-meetcord/Meetcord-App/assets/90755664/a05d412e-2eaf-4316-9181-e147917d1404">

https://github.com/mju-meetcord/Meetcord-App/assets/90755664/84aefd4f-d8d8-45ad-b8fa-4b97260b2cb6

**_2. 일정 편집_**
<img width="828" alt="Screenshot 2023-05-28 at 5 42 27 PM" src="https://github.com/mju-meetcord/Meetcord-App/assets/90755664/b44b469e-ebe1-43ef-9bfc-b66ecff12736">

https://github.com/mju-meetcord/Meetcord-App/assets/90755664/2f852e9f-73f2-41b1-bab3-cc281166d48f




- [x] 라이브러리 적용으로 인한 디자인 변경 디자이너님 의논과 픽스 -> 특히 시간 부분 없어지며 생긴 여백!
- [x] android time select 시 onChage 반영 
- [x] android time select language 변경 -> 디바이스 language 맞춰 변환됩니다~
- [x] android time picker 이슈 -> 자체 구현으로 해결
- [x] android time picker 활성화 시 text color 변경
- [x] 하루 종일 switch 활성화 시 time picker 비활성화
- [x] 제목 미입력 시 추가 버튼 비활성화 
- [x] 슬라이딩 애니메이션 효과 구현
- [x] 일정 편집 / 삭제
- [x] HomeScreen,App,types등 임시 작업한 거 머지 전 지우기.
- [ ]  android time picker 이슈 해결 다른 대안 알아보기 (기존 그냥 유지? 안드로이드용 Picker 서치 후 다운?)
   - 이슈: 렌더링 시 picker 즉시 호출(조건부렌더링으로 우선 해결), picker show위한 time block이 invisible(수동 버튼 구현)



더 괜찮은 저희 피그마와 더 흡사한 라이브러리가 있다면 언제든 피드백 부탁드립니다.
 